### PR TITLE
fix: fixed input parameter naming

### DIFF
--- a/indykite_sdk_node/src/examples/identity_knowledge.ts
+++ b/indykite_sdk_node/src/examples/identity_knowledge.ts
@@ -1,0 +1,11 @@
+import { IdentityKnowledgeClient } from '../sdk/knowledge';
+
+IdentityKnowledgeClient.createInstance().then((ikClient) => {
+  const path = '(:Organization)';
+  const resp = ikClient.read(path, '', {});
+  console.log(JSON.stringify(resp));
+
+  ikClient.listNodes('Organization').then((response) => {
+    console.log(JSON.stringify(response));
+  });
+});

--- a/indykite_sdk_node/src/sdk/__test__/knowledge/knowledge.test.ts
+++ b/indykite_sdk_node/src/sdk/__test__/knowledge/knowledge.test.ts
@@ -464,6 +464,8 @@ describe('listNodes', () => {
       expect(sdk['client'].identityKnowledge).toBeCalledTimes(1);
       expect(sdk['client'].identityKnowledge).toBeCalledWith(
         {
+          conditions: '',
+          inputParams: {},
           operation: Operation.READ,
           path: '(:DigitalTwin)',
         },
@@ -918,7 +920,7 @@ describe('getNodeByIdentifier', () => {
         {
           operation: Operation.READ,
           path: '(n:DigitalTwin)',
-          conditions: 'WHERE n.external_id = $external_id AND n.type = $type',
+          conditions: 'WHERE n.external_id = $externalId AND n.type = $type',
           inputParams: {
             externalId: {
               value: {
@@ -1233,6 +1235,8 @@ describe('listDigitalTwins', () => {
       expect(sdk['client'].identityKnowledge).toBeCalledTimes(1);
       expect(sdk['client'].identityKnowledge).toBeCalledWith(
         {
+          conditions: '',
+          inputParams: {},
           operation: Operation.READ,
           path: '(:DigitalTwin)',
         },
@@ -1310,6 +1314,8 @@ describe('listResources', () => {
       expect(sdk['client'].identityKnowledge).toBeCalledTimes(1);
       expect(sdk['client'].identityKnowledge).toBeCalledWith(
         {
+          conditions: '',
+          inputParams: {},
           operation: Operation.READ,
           path: '(:Resource)',
         },
@@ -1570,7 +1576,7 @@ describe('getResourceByIdentifier', () => {
         {
           operation: Operation.READ,
           path: '(n:Resource)',
-          conditions: 'WHERE n.external_id = $external_id AND n.type = $type',
+          conditions: 'WHERE n.external_id = $externalId AND n.type = $type',
           inputParams: {
             externalId: {
               value: {
@@ -1664,7 +1670,7 @@ describe('getDigitalTwinByIdentifier', () => {
         {
           operation: Operation.READ,
           path: '(n:DigitalTwin)',
-          conditions: 'WHERE n.external_id = $external_id AND n.type = $type',
+          conditions: 'WHERE n.external_id = $externalId AND n.type = $type',
           inputParams: {
             externalId: {
               value: {

--- a/indykite_sdk_node/src/sdk/knowledge.ts
+++ b/indykite_sdk_node/src/sdk/knowledge.ts
@@ -192,6 +192,8 @@ export class IdentityKnowledgeClient {
     const request: IdentityKnowledgeRequest = {
       operation: Operation.READ,
       path: `(:${nodeType})`,
+      conditions: '',
+      inputParams: {},
     } as IdentityKnowledgeRequest;
     return new Promise((resolve, reject) => {
       this.identityKnowledge(request)

--- a/indykite_sdk_node/src/sdk/knowledge.ts
+++ b/indykite_sdk_node/src/sdk/knowledge.ts
@@ -246,7 +246,7 @@ export class IdentityKnowledgeClient {
     const request: IdentityKnowledgeRequest = {
       operation: Operation.READ,
       path: `(n:${nodeType})`,
-      conditions: `WHERE n.external_id = $external_id AND n.type = $type`,
+      conditions: `WHERE n.external_id = $externalId AND n.type = $type`,
       inputParams: {
         externalId: InputParam.fromJson(Utils.objectToJsonValue(identifier.externalId)),
         type: InputParam.fromJson(Utils.objectToJsonValue(identifier.type)),


### PR DESCRIPTION
# Description

[ENG-2091](https://indykite.atlassian.net/browse/ENG-2091) 
This is a bug in the getNodeByIdentifier function in the Node SDK. In the line WHERE n.external_id = $external_id AND n.type = $type we say that the external_id param needs to be snake case. However in the inputParams field, we specify it as camelCase. If the conditions contained WHERE n.external_id = $externalId AND n.type = $type it would work. So we either need to change the conditions to match the inputParams field, or vice versa.
Included [ENG-2094](https://indykite.atlassian.net/browse/ENG-2094) BUG: Serialization failure in IKG API listXX functions

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG



[ENG-2091]: https://indykite.atlassian.net/browse/ENG-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-2094]: https://indykite.atlassian.net/browse/ENG-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ